### PR TITLE
Allow for the visible property to be the only property to be used to display the map. 

### DIFF
--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -171,8 +171,8 @@ class StaticMapController {
     this.signature,
     this.visible,
   })  : assert(
-          (center != null && zoom != null) || markers != null,
-          "center and zoom should be provided when markers are not",
+          (center != null && zoom != null) || markers != null || visible != null,
+          "One of the following should be provided in order to draw a map: center & zoom, or markers, or visible.",
         ),
         assert(
           !(styles != null && mapId != null),


### PR DESCRIPTION
Allow for the visible property to be used to display the map. This way, you can set a polyline to always be visible regardless of it's size, zo zoom isn't necessary.